### PR TITLE
Support arbitrary volume mount for doc build using Docker

### DIFF
--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -1,10 +1,10 @@
 ---
 name: test-docs-preview
 
-on:
-  workflow_dispatch:
-  pull_request_target:
-    types: [opened]
+#on:
+#  workflow_dispatch:
+#  pull_request_target:
+#    types: [opened]
 
 permissions:
   pull-requests: write

--- a/build_docs
+++ b/build_docs
@@ -311,6 +311,9 @@ def run_build_docs(args):
             mounted_path = mount_docs_repo_and_dockerify_path(sub_dir, sub_dir)
             build_docs_args.append("%s:%s:%s" % (
                     m.group('repo'), m.group('branch'), mounted_path))
+        elif arg == '--extra_docker_vol_mount':
+            mount_spec = args.next_arg_or_err()
+            docker_args.extend(['-v', mount_spec])
         arg = args.next_arg()
 
     # Mount alternatives used by the docs repo if there are any in case we have

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -1020,6 +1020,7 @@ sub command_line_opts {
         'open',
         'procs=i',
         'verbose',
+        'extra_docker_vol_mount'
     ];
 }
 


### PR DESCRIPTION
This PR fixes errors from some doc builds:

<img width="1223" alt="error" src="https://github.com/QubitPi/elastic-docs/assets/16126939/9db7e7e1-632f-4d62-9418-b5630c0fa8e5">